### PR TITLE
Updated minimal-notebook container to pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ People have used it at user groups, meetups, and workshops to provide temporary 
 Get Docker, then:
 
 ```
-docker pull jupyter/minimal
+docker pull jupyter/minimal-notebook:latest
 export TOKEN=$( head -c 30 /dev/urandom | xxd -p )
 docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=proxy jupyter/configurable-http-proxy --default-target http://127.0.0.1:9999
 docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=tmpnb -v /var/run/docker.sock:/docker.sock jupyter/tmpnb


### PR DESCRIPTION
when starting the `jupyter/tmpnb` container it complains with

```
 docker.errors.NotFound: 404 Client Error: Not Found ("b'No such image: jupyter/minimal-notebook:latest'")
```

pulling `docker pull jupyter/minimal-notebook:latest` instead makes it work.

Thanks for the cool project! Could you enable GH issues?
